### PR TITLE
feat: Extend model support in convert_gguf_to_hf.py

### DIFF
--- a/convert_gguf_to_hf.py
+++ b/convert_gguf_to_hf.py
@@ -59,16 +59,66 @@ def main() -> None:
     # Try to get model type from GGUF metadata for config.json
     # This is a heuristic and might need adjustment based on common GGUF metadata
     model_type_map = {
-        "llama": "LlamaForCausalLM",
+        "llama": "LlamaForCausalLM",  # Covers LLaMAForCausalLM, MistralForCausalLM, MixtralForCausalLM, InternLM3ForCausalLM
         "gptneox": "GPTNeoXForCausalLM",
         "gpt2": "GPT2LMHeadModel",
-        "phi2": "PhiForCausalLM",
+        "phi2": "PhiForCausalLM",  # Covers PhiForCausalLM
         "phi3": "Phi3ForCausalLM",
+        "phimoe": "PhiMoEForCausalLM",
         "gemma": "GemmaForCausalLM",
         "gemma2": "Gemma2ForCausalLM",
+        "gemma3": "Gemma3ForCausalLM", # Covers Gemma3ForConditionalGeneration
+        "starcoder": "GPTBigCodeForCausalLM", # GGUF name is starcoder, HF is GPTBigCodeForCausalLM
         "starcoder2": "Starcoder2ForCausalLM",
+        "qwen": "QWenLMHeadModel",
         "qwen2": "Qwen2ForCausalLM",
-        # Add more mappings as needed
+        "qwen2vl": "Qwen2VLForConditionalGeneration", # Covers Qwen2_5_VLForConditionalGeneration
+        "qwen2moe": "Qwen2MoeForCausalLM",
+        "bloom": "BloomForCausalLM", # Covers BloomModel
+        "mpt": "MPTForCausalLM",
+        "orion": "OrionForCausalLM",
+        "baichuan": "BaichuanForCausalLM", # Covers BaiChuanForCausalLM
+        "xverse": "XverseForCausalLM",
+        "falcon": "FalconForCausalLM", # Covers RWForCausalLM
+        "refact": "GPTRefactForCausalLM",
+        "stablelm": "StableLmForCausalLM", # Covers StableLMEpochForCausalLM, LlavaStableLMEpochForCausalLM
+        "deci": "DeciLMForCausalLM",
+        "bitnet": "BitnetForCausalLM",
+        "grok": "GrokForCausalLM",
+        "dbrx": "DbrxForCausalLM",
+        "minicpm": "MiniCPMForCausalLM",
+        "minicpm3": "MiniCPM3ForCausalLM",
+        "wavtokenizer_dec": "WavTokenizerDecModel", # Needs specific class if not a standard HF one
+        "plamo": "PlamoForCausalLM",
+        "codeshell": "CodeShellForCausalLM",
+        "internlm2": "InternLM2ForCausalLM",
+        "bert": "BertModel", # Covers BertForMaskedLM, CamembertModel, RobertaModel, XLMRobertaModel, XLMRobertaForSequenceClassification
+        "nomic_bert": "NomicBertModel",
+        "rwkv6": "Rwkv6ForCausalLM",
+        "rwkv6qwen2": "RWKV6Qwen2ForCausalLM",
+        "rwkv7": "Rwkv7ForCausalLM", # Covers RWKV7ForCausalLM
+        "arwkv7": "RwkvHybridForCausalLM",
+        "mamba": "MambaForCausalLM", # Covers MambaLMHeadModel, FalconMambaForCausalLM
+        "command_r": "CohereForCausalLM",
+        "cohere2": "Cohere2ForCausalLM",
+        "olmo": "OlmoForCausalLM", # Covers OLMoForCausalLM
+        "olmo2": "Olmo2ForCausalLM",
+        "olmoe": "OlmoeForCausalLM",
+        "jina_bert_v2": "JinaBertModel", # Covers JinaBertForMaskedLM
+        "openelm": "OpenELMForCausalLM",
+        "arctic": "ArcticForCausalLM",
+        "deepseek": "DeepseekForCausalLM",
+        "deepseek2": "DeepseekV2ForCausalLM", # Covers DeepseekV3ForCausalLM
+        "plm": "PLMForCausalLM",
+        "t5": "T5WithLMHeadModel", # Covers T5ForConditionalGeneration, MT5ForConditionalGeneration, UMT5ForConditionalGeneration
+        "t5encoder": "T5EncoderModel",
+        "jais": "JAISLMHeadModel",
+        "chatglm": "GlmForCausalLM", # Covers ChatGLMModel, ChatGLMForConditionalGeneration
+        "nemotron": "NemotronForCausalLM",
+        "exaone": "ExaoneForCausalLM",
+        "granite": "GraniteForCausalLM",
+        "granite_moe": "GraniteMoeForCausalLM",
+        "chameleon": "ChameleonForConditionalGeneration", # Covers ChameleonForCausalLM
     }
     hf_model_type = model_type_map.get(model_arch_name.lower(), "AutoModelForCausalLM")
     print(f"Inferred Hugging Face model type: {hf_model_type}")
@@ -100,8 +150,35 @@ def main() -> None:
         config_data["num_attention_heads"] = get_gguf_int_val(gguf.Keys.LLAMA.HEAD_COUNT)
         if (kv_heads := get_gguf_int_val(gguf.Keys.LLAMA.HEAD_COUNT_KV)) is not None:
             config_data["num_key_value_heads"] = kv_heads
-        config_data["rms_norm_eps"] = get_gguf_float_val(gguf.Keys.LLAMA.LAYER_NORM_RMS_EPS, 1e-5)
+
+        # Norm EPS
+        if (rms_norm_eps := get_gguf_float_val(gguf.Keys.LLAMA.LAYER_NORM_RMS_EPS)) is not None:
+            config_data["rms_norm_eps"] = rms_norm_eps
+        if (layer_norm_eps := get_gguf_float_val(gguf.Keys.LLAMA.LAYER_NORM_EPS)) is not None:
+            config_data["layer_norm_eps"] = layer_norm_eps
+
         config_data["max_position_embeddings"] = get_gguf_int_val(gguf.Keys.LLAMA.CONTEXT_LENGTH, 2048)
+
+        # RoPE settings
+        if (rope_theta := get_gguf_float_val(gguf.Keys.LLAMA.ROPE_FREQ_BASE)) is not None:
+            config_data["rope_theta"] = rope_theta
+        if (rope_scaling_factor := get_gguf_float_val(gguf.Keys.LLAMA.ROPE_SCALING_FACTOR)) is not None:
+            # HF config usually expects a dictionary for rope_scaling
+            # This is a basic attempt, might need model-specific handling
+            config_data["rope_scaling"] = {"type": "linear", "factor": rope_scaling_factor} # Assuming linear if factor is present
+            # Some models (e.g. Qwen2) might use 'yarn' and have 'original_max_position_embeddings'
+            if gguf_reader.get_field(gguf.Keys.LLAMA.ROPE_SCALING_TYPE) and \
+               bytes(gguf_reader.get_field(gguf.Keys.LLAMA.ROPE_SCALING_TYPE).parts[-1]).decode("utf-8").lower() == "yarn":
+                config_data["rope_scaling"]["type"] = "yarn"
+                if (orig_max_pos_emb := get_gguf_int_val(gguf.Keys.LLAMA.ROPE_SCALING_ORIG_CTX_LEN)) is not None:
+                    config_data["rope_scaling"]["original_max_position_embeddings"] = orig_max_pos_emb
+
+        # MoE parameters
+        if (expert_count := get_gguf_int_val(gguf.Keys.LLAMA.EXPERT_COUNT)) is not None:
+            config_data["num_local_experts"] = expert_count
+        if (experts_used_count := get_gguf_int_val(gguf.Keys.LLAMA.EXPERT_USED_COUNT)) is not None:
+            config_data["num_experts_per_tok"] = experts_used_count
+
         config_data["torch_dtype"] = "float16" # As per requirement
         config_data["architectures"] = [hf_model_type]
 
@@ -152,31 +229,68 @@ def main() -> None:
         # For now, we assume direct mapping of shapes if possible.
         # More sophisticated logic might be needed here based on common GGUF conventions
         # or specific model architecture quirks.
+        # TODO: Implement architecture-specific tensor transformations by reversing
+        #       the logic in the corresponding convert_hf_to_gguf.py model classes.
         try:
-            expected_shape = hf_model.state_dict(keep_vars=True)[hf_tensor_name].shape
+            # It's better to get the expected shape from the uninitialized model's parameters
+            # to avoid issues if a tensor is already (incorrectly) on a real device.
+            expected_param = hf_model.get_parameter(hf_tensor_name)
+            expected_shape = expected_param.shape
+
             if tensor.shape != expected_shape:
-                print(f"  Warning: Shape mismatch for {hf_tensor_name}. GGUF: {tensor.shape}, HF: {expected_shape}. Attempting reshape/view.")
-                # This is a very basic attempt. More complex transpositions might be needed.
-                try:
-                    tensor = tensor.reshape(expected_shape)
-                except RuntimeError as e:
-                    print(f"    Error reshaping {hf_tensor_name}: {e}. Tensor will likely be incorrect.")
+                print(f"  Warning: Shape mismatch for '{hf_tensor_name}'. GGUF: {tensor.shape}, HF: {expected_shape}.")
+                # Attempt common transformations
+                if tensor.squeeze().shape == expected_shape:
+                    print(f"    Attempting to squeeze tensor '{hf_tensor_name}'.")
+                    tensor = tensor.squeeze()
+                elif tensor.T.shape == expected_shape:
+                    print(f"    Attempting to transpose tensor '{hf_tensor_name}'.")
+                    tensor = tensor.T
+                elif len(tensor.shape) == len(expected_shape):
+                    try:
+                        print(f"    Attempting to reshape tensor '{hf_tensor_name}'.")
+                        tensor = tensor.reshape(expected_shape)
+                    except RuntimeError as e_reshape:
+                        print(f"    Error reshaping '{hf_tensor_name}': {e_reshape}. Trying transpose then reshape.")
+                        try:
+                            tensor = tensor.T.reshape(expected_shape)
+                            print(f"    Successfully transposed and reshaped '{hf_tensor_name}'.")
+                        except RuntimeError as e_t_reshape:
+                             print(f"    Error transposing and reshaping '{hf_tensor_name}': {e_t_reshape}. Tensor will likely be incorrect.")
+                else:
+                    print(f"    Cannot automatically fix shape for '{hf_tensor_name}'. Manual intervention may be needed based on model architecture.")
         except KeyError:
-            print(f"  Warning: Tensor {hf_tensor_name} not found in initialized HF model's state_dict. This could be an issue with the tensor map or model config.")
+            print(f"  Warning: Tensor '{hf_tensor_name}' not found in initialized HF model's state_dict. This could be an issue with the tensor map or model config.")
+        except AttributeError: # For non-parameter tensors if any were to be mapped
+             print(f"  Info: '{hf_tensor_name}' is not a parameter in the HF model, skipping shape check.")
 
 
         state_dict[hf_tensor_name] = tensor
 
     # Load the state dict into the model
+    # Using assign=True allows loading onto the 'meta' device initially
     try:
-        hf_model.load_state_dict(state_dict, assign=True, strict=False) # strict=False to allow for missing/extra keys for now
-        print("Successfully loaded state_dict into the model (strict=False).")
+        errors = hf_model.load_state_dict(state_dict, assign=True, strict=False)
+        if errors.missing_keys:
+            print(f"Warning: Missing keys in state_dict: {errors.missing_keys}")
+        if errors.unexpected_keys:
+            print(f"Warning: Unexpected keys in state_dict: {errors.unexpected_keys}")
+        print("Successfully loaded state_dict into the model.")
     except Exception as e:
         print(f"Error loading state_dict: {e}")
         print("This could be due to shape mismatches or missing/unexpected tensors.")
-        print("Run with --verbose and check tensor processing messages.")
+        print("Run with --verbose and check tensor processing messages for clues.")
         sys.exit(1)
 
+    # Materialize the model from 'meta' device to CPU (or other target device)
+    # This is where actual memory allocation happens.
+    print("Materializing model...")
+    try:
+        hf_model.to_empty(device="cpu") # First move to empty on target device
+        hf_model.load_state_dict(state_dict) # Then load the actual data
+    except Exception as e:
+        print(f"Error materializing model: {e}")
+        sys.exit(1)
 
     print(f"Saving Hugging Face model to: {args.output_dir}")
     hf_model.save_pretrained(args.output_dir)


### PR DESCRIPTION
- Updated model_type_map to include a wider range of architectures found in convert_hf_to_gguf.py.
- Enhanced Hugging Face configuration reconstruction by mapping more GGUF metadata keys (e.g., RoPE params, norm EPS, MoE params).
- Improved tensor loading logic with more robust shape handling (attempting transpose on reshape failure) and clearer warnings.
- Adjusted model materialization for meta device initialization.

*Make sure to read the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md) before submitting a PR*
